### PR TITLE
Revert "Disable UART logs"

### DIFF
--- a/arch/arm64/boot/dts/qcom/waipio.dtsi
+++ b/arch/arm64/boot/dts/qcom/waipio.dtsi
@@ -20,7 +20,7 @@
 	#size-cells = <2>;
 
 	chosen: chosen {
-		bootargs = "loglevel=6 kpti=0 log_buf_len=256K kernel.panic_on_rcu_stall=1 swiotlb=noforce loop.max_part=7 cgroup.memory=nokmem,nosocket pcie_ports=compat service_locator.enable=1 msm_rtb.filter=0x237 allow_mismatched_32bit_el0 cpufreq.default_governor=performance pelt=8 kasan=off rcupdate.rcu_expedited=1 rcu_nocbs=0-7 irqaffinity=0-3 ftrace_dump_on_oops pstore.compress=none fsa4480_i2c.async_probe=1 can.stats_timer=0 slub_debug=-";
+		bootargs = "console=ttyMSM0,115200n8 loglevel=6 kpti=0 log_buf_len=256K kernel.panic_on_rcu_stall=1 swiotlb=noforce loop.max_part=7 cgroup.memory=nokmem,nosocket pcie_ports=compat service_locator.enable=1 msm_rtb.filter=0x237 allow_mismatched_32bit_el0 cpufreq.default_governor=performance pelt=8 kasan=off rcupdate.rcu_expedited=1 rcu_nocbs=0-7 irqaffinity=0-3 ftrace_dump_on_oops pstore.compress=none fsa4480_i2c.async_probe=1 can.stats_timer=0 slub_debug=-";
 		stdout-path = "/soc/qcom,qup_uart@99c000:115200n8";
 	};
 
@@ -3478,11 +3478,11 @@
 };
 
 &qupv3_se7_2uart {
-	status = "disabled";
+	status = "ok";
 };
 
 &qupv3_se20_4uart {
-	status = "disabled";
+	status = "ok";
 };
 
 &qupv3_se5_i2c {


### PR DESCRIPTION
This reverts commit 65285057c9ccd13b028e7708478e3d38ced71e34.

Enable UART again, this also fixes bluetooth crashes as the chip uses UART interface 