### PR TITLE
[BUG-98994] Disable watchdog feature for touchpanel driver

### DIFF
--- a/arch/arm64/boot/dts/qcom/sec_touchscreen.dtsi
+++ b/arch/arm64/boot/dts/qcom/sec_touchscreen.dtsi
@@ -31,8 +31,6 @@
 		sec,device_id = /bits/ 8 <0xAC 0x37 0x92>;
 
 		/* feature */
-		sec,watchdog_supported = <1>;
-		sec,watchdog_delay_ms = <10000>;
 		sec,side_touch_supported = <0>;
 		sec,glove_mode_supported = <0>;
 		sec,cover_mode_supported = <0>;


### PR DESCRIPTION
- Looks like there is a race condition in the touchpanel driver which write the same data to the list.
- This causes a kernel crash