### PR TITLE
msm-geni: Avoid adding duplicate items to list

### DIFF
--- a/drivers/platform/msm/msm-geni-se.c
+++ b/drivers/platform/msm/msm-geni-se.c
@@ -753,6 +753,13 @@ static int geni_se_rmv_ab_ib(struct geni_se_device *geni_se_dev,
 
 	mutex_lock(&geni_se_dev->geni_dev_lock);
 
+	if (!rsc->is_added_to_list) {
+		pr_err("%s: %s: already removed from list\n", __func__,
+			dev_name(rsc->ctrl_dev));
+		mutex_unlock(&geni_se_dev->geni_dev_lock);
+		return ret;
+	}
+
 	list_del_init(&rsc->ab_list);
 	geni_se_dev->cur_ab -= rsc->ab;
 
@@ -819,6 +826,7 @@ static int geni_se_rmv_ab_ib(struct geni_se_device *geni_se_dev,
 			geni_se_dev->cur_ab_noc, geni_se_dev->cur_ib_noc,
 			rsc->ab_noc, rsc->ib_noc, bus_bw_update_noc);
 	}
+	rsc->is_added_to_list = false;
 	mutex_unlock(&geni_se_dev->geni_dev_lock);
 	return ret;
 }
@@ -905,6 +913,13 @@ static int geni_se_add_ab_ib(struct geni_se_device *geni_se_dev,
 
 	mutex_lock(&geni_se_dev->geni_dev_lock);
 
+	if (rsc->is_added_to_list) {
+		pr_err("%s: %s: already exists in list\n", __func__,
+			dev_name(rsc->ctrl_dev));
+		mutex_unlock(&geni_se_dev->geni_dev_lock);
+		return ret;
+	}
+
 	list_add(&rsc->ab_list, &geni_se_dev->ab_list_head);
 	geni_se_dev->cur_ab += rsc->ab;
 
@@ -974,6 +989,7 @@ static int geni_se_add_ab_ib(struct geni_se_device *geni_se_dev,
 			geni_se_dev->cur_ab_noc, geni_se_dev->cur_ib_noc,
 			rsc->ab_noc, rsc->ib_noc, bus_bw_update_noc);
 	}
+	rsc->is_added_to_list = true;
 	mutex_unlock(&geni_se_dev->geni_dev_lock);
 	return ret;
 }
@@ -1003,6 +1019,7 @@ int se_geni_clks_on(struct se_geni_rsc *rsc)
 
 	ret = geni_se_add_ab_ib(geni_se_dev, rsc);
 	if (ret) {
+		geni_se_rmv_ab_ib(geni_se_dev, rsc);
 		GENI_LOG_ERR(geni_se_dev->log_ctx, false, geni_se_dev->dev,
 			"%s: %s: Error %d during bus_bw_update\n", __func__,
 			dev_name(rsc->ctrl_dev), ret);

--- a/include/linux/msm-geni-se.h
+++ b/include/linux/msm-geni-se.h
@@ -74,6 +74,7 @@ struct se_geni_rsc {
 	unsigned int num_clk_levels;
 	unsigned long *clk_perf_tbl;
 	enum se_protocol_types proto;
+	bool is_added_to_list;
 };
 
 #define PINCTRL_DEFAULT	"default"


### PR DESCRIPTION
- On our samsung touchpanel driver there is a race condition or a timeout occurs during suspend/resume which leads to clock voting twice.
- While doing this the driver calls list_add twice without list_del.
- kernel does not allow duplicate entries in the list and causes a kernel panic at list_add.
- Fix this by adding a check in the driver.